### PR TITLE
Use real source URL and known sha256 when mirroring blobs

### DIFF
--- a/src/pages/Transfer.tsx
+++ b/src/pages/Transfer.tsx
@@ -157,13 +157,17 @@ export const Transfer = () => {
         }));
 
         await transferBlob(
-          `${serverInfo[sourceServer].url}/${b.sha256}`,
+          // Use the blob descriptor's real URL. Reconstructing it as
+          // `<server>/<sha256>` only works for Blossom servers; NIP-96 sources
+          // (where the file lives under a different host/path) would 404.
+          b.url || `${serverInfo[sourceServer].url}/${b.sha256}`,
           serverInfo[targetServer],
           signEventTemplate,
           {
             signal: controller.signal,
             timeout: 120000,
             maxRetries: 2,
+            sourceSha256: b.sha256,
             allowMirror: mirrorSupport[targetServer] !== false,
             onMirrorUnsupported: () => {
               setMirrorSupport(ms => ({ ...ms, [targetServer]: false }));

--- a/src/utils/blossom.ts
+++ b/src/utils/blossom.ts
@@ -185,9 +185,15 @@ export const mirrordBlossomBlob = async (
   targetServer: string,
   sourceUrl: string,
   signEventTemplate: (template: EventTemplate) => Promise<SignedEvent>,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  sha256?: string
 ) => {
-  const hash = extractHashFromUrl(sourceUrl);
+  // Prefer the caller-provided hash. Extracting it from the URL is unreliable
+  // for non-Blossom sources (e.g. NIP-96 CDN URLs like
+  // https://cdn.example/<pubkey>/<sha256>.png contain two 64-hex segments, and
+  // the regex would grab the pubkey). The server verifies the downloaded bytes
+  // against the auth event's `x` tag, so an incorrect hash yields a 403.
+  const hash = sha256 || extractHashFromUrl(sourceUrl);
   console.log({ sourceUrl, hash });
   if (!hash) throw 'The soureUrl does not contain a blossom hash.';
 

--- a/src/utils/transfer.ts
+++ b/src/utils/transfer.ts
@@ -14,6 +14,8 @@ export interface TransferOptions {
   maxRetries?: number;
   allowMirror?: boolean;
   onMirrorUnsupported?: () => void;
+  /** Known sha256 of the source blob, used for the mirror auth `x` tag. */
+  sourceSha256?: string;
 }
 
 class SourceBlobNotFoundError extends Error {
@@ -90,6 +92,7 @@ export const transferBlob = async (
     maxRetries = 2,
     allowMirror = true,
     onMirrorUnsupported,
+    sourceSha256,
   } = options;
 
   console.log({ sourceUrl, targetServer });
@@ -129,7 +132,8 @@ export const transferBlob = async (
     if (targetServer.type == 'blossom' && allowMirror) {
       try {
         onPhaseChange?.('mirroring');
-        const mirrorFn = () => mirrordBlossomBlob(targetServer.url, sourceUrl, signEventTemplate, signal);
+        const mirrorFn = () =>
+          mirrordBlossomBlob(targetServer.url, sourceUrl, signEventTemplate, signal, sourceSha256);
         const blob = await withTimeout(
           retryWithBackoff(mirrorFn, maxRetries, signal),
           timeout,


### PR DESCRIPTION
Mirroring reconstructed the source URL as `<server>/<sha256>`, which 404s for NIP-96 sources where the blob lives under a different host/path, and derived the auth `x` tag by regex-extracting a hash from the URL (NIP-96 CDN URLs carry both a pubkey and a sha256, so it could pick the wrong one). Pass the blob descriptor's real URL and its known sha256 through to the mirror auth instead.