### PR TITLE
feat: make image proxy configurable via VITE_IMAGE_PROXY

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,30 @@ Preview production build locally:
 npm run preview
 ```
 
+## Configuration
+
+### Image proxy
+
+Thumbnails are generated through an image proxy. By default the public
+[slidestr](https://images.slidestr.net) proxy is used. To use your own proxy,
+set the `VITE_IMAGE_PROXY` environment variable (e.g. in a `.env` file) to a URL
+template:
+
+```bash
+# .env
+VITE_IMAGE_PROXY=https://my-proxy.example.com/insecure/f:webp/rs:fill:{size}/plain/{url}
+```
+
+Supported placeholders:
+
+- `{url}` raw source image URL
+- `{encodedUrl}` URL-encoded source image URL
+- `{size}` requested thumbnail size in pixels
+
+If neither `{url}` nor `{encodedUrl}` is present, the source URL is appended to
+the end of the template. Set `VITE_IMAGE_PROXY=` (empty) to load images directly
+without any proxy.
+
 ## Scripts
 
 - `npm run dev` start Vite dev server

--- a/src/components/FileEventEditor/FileEventEditor.tsx
+++ b/src/components/FileEventEditor/FileEventEditor.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { extractDomain, formatFileSize } from '../../utils/utils';
+import { getProxyUrl } from '../../utils/imageProxy';
 import { fetchId3Tag } from '../../utils/id3';
 import useVideoThumbnailDvm from './dvm';
 import TagInput from '../TagInput';
@@ -107,13 +108,6 @@ const FileEventEditor = ({
       });
     }
   }, [fileEventData]);
-
-  const getProxyUrl = (url: string) => {
-    if (url.startsWith('blob:')) {
-      return url;
-    }
-    return `https://images.slidestr.net/insecure/f:webp/rs:fill:600/plain/${url}`;
-  };
 
   useEffect(() => {
     if (fileEventData.selectedThumbnail == undefined) {

--- a/src/components/ImageBlobList/ImageBlobList.tsx
+++ b/src/components/ImageBlobList/ImageBlobList.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { formatFileSize, formatDate } from '../../utils/utils';
+import { getProxyUrl } from '../../utils/imageProxy';
 import { Clipboard } from 'lucide-react';
 import { BlobDescriptor } from 'blossom-client-sdk';
 import { HandleSelectBlobType } from '../BlobList/useBlobSelection';
@@ -42,7 +43,7 @@ const ImageBlobList = ({ images, handleSelectBlob, selectedBlobs }: ImageBlobLis
               <div
                 className="bg-center bg-no-repeat bg-contain cursor-pointer inline-block w-[90vw] md:w-[200px] h-[200px]"
                 style={{
-                  backgroundImage: `url(https://images.slidestr.net/insecure/f:webp/rs:fill:300/plain/${blob.url})`,
+                  backgroundImage: `url(${getProxyUrl(blob.url, 300)})`,
                 }}
               ></div>
             </a>

--- a/src/components/UploadPublished.tsx
+++ b/src/components/UploadPublished.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { FileEventData } from './FileEventEditor/FileEventEditor';
 import type { NostrEvent } from 'nostr-tools';
 import { KIND_AUDIO, KIND_FILE_META, KIND_VIDEO_HORIZONTAL, KIND_VIDEO_VERTICAL } from '../utils/useFileMetaEvents';
+import { getProxyUrl } from '../utils/imageProxy';
 import { nip19 } from 'nostr-tools';
 import { Link } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
@@ -78,7 +79,7 @@ const FileEvent = ({ event }: { event: NostrEvent }) => {
           <img
             width={128}
             height={128}
-            src={`https://images.slidestr.net/insecure/f:webp/rs:fill:600/plain/${data.thumbnail}`}
+            src={getProxyUrl(data.thumbnail, 600)}
             className="w-full"
           />
         </div>

--- a/src/utils/imageProxy.ts
+++ b/src/utils/imageProxy.ts
@@ -1,0 +1,42 @@
+// Default image proxy. `{size}` is replaced with the requested edge size and
+// `{url}` with the (raw, unencoded) source image URL.
+export const DEFAULT_IMAGE_PROXY = 'https://images.slidestr.net/insecure/f:webp/rs:fill:{size}/plain/{url}';
+
+// The image proxy URL template, overridable at build time via the
+// `VITE_IMAGE_PROXY` environment variable. Set it to an empty string to load
+// images directly without any proxy.
+export const IMAGE_PROXY_TEMPLATE =
+  import.meta.env.VITE_IMAGE_PROXY !== undefined ? import.meta.env.VITE_IMAGE_PROXY : DEFAULT_IMAGE_PROXY;
+
+/**
+ * Builds a proxied image URL from the configured template.
+ *
+ * Supported placeholders:
+ * - `{url}`        raw source URL
+ * - `{encodedUrl}` `encodeURIComponent`-ed source URL
+ * - `{size}`       requested edge size in pixels
+ *
+ * When the template contains neither `{url}` nor `{encodedUrl}` the source URL
+ * is appended to the end of the template. An empty template (or a `blob:` /
+ * `data:` source) returns the original URL unchanged so previews keep working.
+ */
+export function getProxyUrl(url: string | undefined, size = 600): string {
+  if (!url || url.startsWith('blob:') || url.startsWith('data:')) {
+    return url ?? '';
+  }
+
+  const template = (IMAGE_PROXY_TEMPLATE ?? '').trim();
+  if (!template) {
+    return url;
+  }
+
+  let result = template.replaceAll('{size}', String(size)).replaceAll('{encodedUrl}', encodeURIComponent(url));
+
+  if (result.includes('{url}')) {
+    result = result.replaceAll('{url}', url);
+  } else if (!template.includes('{encodedUrl}')) {
+    result += url;
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary

The image proxy used to generate thumbnails was hardcoded to the public `images.slidestr.net` endpoint in three places. This PR makes it configurable so anyone can point Bouquet at their own image proxy (or disable it entirely).

## Changes

- Add `src/utils/imageProxy.ts` with a `getProxyUrl(url, size)` helper driven by the `VITE_IMAGE_PROXY` env var.
  - Supports `{url}`, `{encodedUrl}` and `{size}` placeholders.
  - Falls back to the existing slidestr default when unset.
  - Setting `VITE_IMAGE_PROXY=` (empty) loads images directly without any proxy.
  - `blob:` / `data:` sources are returned unchanged.
- Replace the three hardcoded slidestr URLs with `getProxyUrl()`:
  - `FileEventEditor.tsx` (removes the local `getProxyUrl` definition)
  - `UploadPublished.tsx`
  - `ImageBlobList/ImageBlobList.tsx`
- Document the `VITE_IMAGE_PROXY` setting in the README.

## Usage

```bash
# .env
VITE_IMAGE_PROXY=https://my-proxy.example.com/insecure/f:webp/rs:fill:{size}/plain/{url}
```

## Testing

- `npx tsc --noEmit` passes.
- `eslint` on the changed files reports no new errors (only pre-existing `react-hooks/exhaustive-deps` warnings).